### PR TITLE
chore: replace once_cell with std equivalents, bump to 1.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "git-hist"
 readme = "README.md"
 repository = "https://github.com/karbassi/git-hist"
-version = "1.0.6"
+version = "1.1.0"
 
 [dependencies]
 anyhow = "1.0"
@@ -17,7 +17,6 @@ clap = {version = "4", features = ["wrap_help", "derive"]}
 crossterm = "0.28"
 git2 = {version = "0.14", features = ["vendored-openssl"]}
 itertools = "0.10"
-once_cell = "1.13"
 similar = {version = "2.1", features = ["bytes", "inline"]}
 ratatui = {version = "0.29", default-features = false, features = ["crossterm"]}
 

--- a/src/app/commit.rs
+++ b/src/app/commit.rs
@@ -1,8 +1,7 @@
 use chrono::TimeZone;
 use git2::{Commit as GitCommit, Oid, Repository};
 use itertools::Itertools;
-use once_cell::sync::OnceCell;
-use std::{collections::HashMap, fmt};
+use std::{collections::HashMap, fmt, sync::OnceLock};
 
 const HEAD_NAME: &str = "HEAD";
 
@@ -15,7 +14,7 @@ pub struct Commit<'a> {
     committer_name: String,
     committer_date: chrono::DateTime<chrono::Local>,
     summary: String,
-    references: OnceCell<References>,
+    references: OnceLock<References>,
     repo: &'a Repository,
 }
 
@@ -53,7 +52,7 @@ impl<'a> Commit<'a> {
             committer_name: committer,
             committer_date,
             summary,
-            references: OnceCell::new(),
+            references: OnceLock::new(),
             repo,
         }
     }

--- a/src/app/dashboard.rs
+++ b/src/app/dashboard.rs
@@ -2,15 +2,15 @@ use crate::app::state::State;
 use crate::app::terminal::Terminal;
 use crate::args::UserType;
 use anyhow::Result;
-use once_cell::sync::Lazy;
 use ratatui::{layout, style, text, widgets};
+use std::sync::LazyLock;
 
 const COMMIT_INFO_INNER_HEIGHT: u16 = 2;
 const COMMIT_INFO_OUTER_HEIGHT: u16 = COMMIT_INFO_INNER_HEIGHT + 2;
 const COMMIT_INFO_HORIZONTAL_PADDING: u16 = 1;
 const NAVI_WIDTH: u16 = 3;
 
-static BINARY_ALERT_TEXT: Lazy<Vec<text::Line<'static>>> = Lazy::new(|| {
+static BINARY_ALERT_TEXT: LazyLock<Vec<text::Line<'static>>> = LazyLock::new(|| {
     vec![
         text::Line::from(vec![text::Span::styled(
             "╭──────────────────────────────────────────────╮",

--- a/src/app/diff.rs
+++ b/src/app/diff.rs
@@ -1,10 +1,9 @@
 use crate::app::state::State;
 use crate::args::Args;
 use git2::{Delta, DiffDelta, Oid, Repository};
-use once_cell::sync::OnceCell;
 use ratatui::style::{Color, Style};
 use similar::{ChangeTag, TextDiff};
-use std::cmp;
+use std::{cmp, sync::OnceLock};
 
 pub struct Diff<'a> {
     status: Delta,
@@ -14,7 +13,7 @@ pub struct Diff<'a> {
     new_path: Option<String>,
     has_old_binary_file: bool,
     has_new_binary_file: bool,
-    lines: OnceCell<Vec<DiffLine>>,
+    lines: OnceLock<Vec<DiffLine>>,
     repo: &'a Repository,
     args: &'a Args,
 }
@@ -43,7 +42,7 @@ impl<'a> Diff<'a> {
                 .find_blob(new_file_oid)
                 .map(|blob| blob.is_binary())
                 .unwrap_or(false),
-            lines: OnceCell::new(),
+            lines: OnceLock::new(),
             repo,
             args,
         }


### PR DESCRIPTION
## Summary
- Replace `once_cell::sync::OnceCell` with `std::sync::OnceLock` in commit.rs and diff.rs
- Replace `once_cell::sync::Lazy` with `std::sync::LazyLock` in dashboard.rs
- Remove `once_cell` dependency from Cargo.toml
- Bump version from 1.0.6 to 1.1.0

Closes #31
Closes #36

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo check` succeeds (full clean build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)